### PR TITLE
Changing the docker image for jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ubuntu:14.04
+      - image: quay.io/deis/go-dev:v1.2.0
     steps:
       # TODO: save the checked-out code in a working directory.
       # do the same with the installed helm and az binaries
@@ -21,7 +21,7 @@ jobs:
           working_directory: scripts
   helm-sync:
     docker:
-      - image: ubuntu:14.04
+      - image: quay.io/deis/go-dev:v1.2.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This image contains a working SSH binary, which should fix builds like these: https://circleci.com/gh/Azure/helm-charts/63. It fixes because a git binary will be installed along with a working SSH installation, which will allow CircleCI to pull from forks.

The discussion [here](https://discuss.circleci.com/t/cant-checkout-code/11592/12) explains the problem in more detail.

If this works, I will be merging this PR without review, as it is a critical fix for all contributors.