### PR TITLE
Fixing the upload URL for the index

### DIFF
--- a/scripts/helm-repo-sync.sh
+++ b/scripts/helm-repo-sync.sh
@@ -29,8 +29,8 @@ done
 #####
 # index the charts, merging with the old index.yaml so charts are versioned
 #####
-REPO_URL=https://kubernetescharts.blob.core.windows.net/
-helm repo index --url $REPO_URL --merge index.yaml .
+REPO_ROOT=https://kubernetescharts.blob.core.windows.net
+helm repo index --url "$REPO_ROOT/$AZURE_STORAGE_CONTAINER" --merge index.yaml .
 
 #####
 # upload to Azure blob storage


### PR DESCRIPTION
Before this change, the helm repo index was pointing to the wrong place for all of the helm charts