### PR TITLE
streamline ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  lint:
     docker:
       - image: quay.io/deis/go-dev:v1.2.0
     steps:
@@ -59,35 +59,34 @@ jobs:
               - master
 workflows:
   version: 2
-  build:
+  test-pr:
     jobs:
       - hold:
           type: approval
           filters:
             branches:
               ignore: master
-      - build:
+      - lint:
           requires:
             - hold
-  test-install-az-cli:
-    jobs:
-      - hold:
-          type: approval
           filters:
             branches:
               ignore: master
       - test-install-az-cli:
           requires:
             - hold
-  build-and-deploy:
+          filters:
+            branches:
+              ignore: master
+  test-and-deploy-master:
     jobs:
-      - build:
+      - lint:
           filters:
             branches:
               only: master
       - helm-sync:
           requires:
-            - build
+            - lint
           filters:
             branches:
               only: master


### PR DESCRIPTION
This should condense two pre-merge CI workflows into just one-- which seems more manageable.

Also renamed the `build` job to `lint`, as it's a more accurate description of what it does.