### PR TITLE
Refactor and fix drupal

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.11.0
+version: 0.12.0
 appVersion: 8.4.2
 description: One of the most versatile open source content management systems.
 keywords:

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -100,7 +100,7 @@ The following configuration options are utilized only if `mysql.embeddedMaria` i
 | Parameter                         | Description                           | Default                                                   |
 | --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
 | `mysql.azure.location`            | The Azure region in which to deploy Azure Database for MySQL | `eastus`                           |
-| `mysql.azure.servicePlan`         | The plan to request for Azure Database for MySQL             | `standard800`                      |
+| `mysql.azure.servicePlan`         | The plan to request for Azure Database for MySQL             | `standard100`                      |
 
 The following configuration options are utilized only if `mysql.embeddedMaria` is set to `true`:
 

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -75,18 +75,12 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `drupalUsername`                  | User of the application               | `user`                                                    |
 | `drupalPassword`                  | Application password                  | _random 10 character long alphanumeric string_            |
 | `drupalEmail`                     | Admin email                           | `user@example.com`                                        |
-| `allowEmptyPassword`              | Allow DB blank passwords              | `yes`                                                     |
 | `extraVars`                       | Extra environment variables           | `nil`                                                     |
 | `ingress.annotations`             | Specify ingress class                 | `kubernetes.io/ingress.class: nginx`                      |
 | `ingress.enabled`                 | Enable ingress controller resource    | `false`                                                   |
 | `ingress.hostname`                | URL for your Drupal installation      | `drupal.local`                                            |
 | `ingress.tls`                     | Ingress TLS configuration             | `[]`                                                      |
-| `mysql.embeddedMaria`                | Whether to fulfill the dependency on MySQL using an embedded (on-cluster) MariaDB database _instead of Aure Database for MySQL. This option is available to enable local or no-cost evaluation of this chart.            | `false`
-| `mariadb.enabled`                 | Use or not the mariadb chart          | `true`                                                    |
-| `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
-| `mariadb.mariadbDatabase`         | Database name to create               | `bitnami_drupal`                                          |
-| `mariadb.mariadbUser`             | Database user to create               | `bn_drupal`                                               |
-| `mariadb.mariadbPassword`         | Password for the database             | _random 10 character long alphanumeric string_            |
+| `mysql.embeddedMaria`             | Whether to fulfill the dependency on MySQL using an embedded (on-cluster) MariaDB database _instead of Azure Database for MySQL_. This option is available to enable local or no-cost evaluation of this chart. | `false` |
 | `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
 | `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `nil` (uses alpha storage class annotation)               |
@@ -100,6 +94,22 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |
 | `volumeMounts.drupal.mountPath`   | Drupal data volume mount path         | `/bitnami/drupal`                                         |
 | `volumeMounts.apache.mountPath`   | Apache data volume mount path         | `/bitnami/apache`                                         |
+
+The following configuration options are utilized only if `mysql.embeddedMaria` is set to `false` (the default):
+
+| Parameter                         | Description                           | Default                                                   |
+| --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
+| `mysql.azure.location`            | The Azure region in which to deploy Azure Database for MySQL | `eastus`                           |
+| `mysql.azure.servicePlan`         | The plan to request for Azure Database for MySQL             | `standard800`                      |
+
+The following configuration options are utilized only if `mysql.embeddedMaria` is set to `true`:
+
+| Parameter                         | Description                           | Default                                                   |
+| --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
+| `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
+| `mariadb.mariadbDatabase`         | Database name to create               | `bitnami_drupal`                                          |
+| `mariadb.mariadbUser`             | Database user to create               | `bn_drupal`                                               |
+| `mariadb.mariadbPassword`         | Password for the database             | _random 10 character long alphanumeric string_            |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 

--- a/drupal/requirements.lock
+++ b/drupal/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.0.5
 digest: sha256:277208f8ee8fd30e560fcd0ed6c6e1a749f273fab29b0dc31a55dd922ca9c278
-generated: 2017-11-30T21:35:05.501264-06:00
+generated: 2017-12-06T12:50:46.312368-05:00

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -24,11 +24,15 @@ spec:
           value: {{ template "drupal.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: DRUPAL_DATABASE_NAME
+          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+        - name: DRUPAL_DATABASE_USER
+          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+        - name: DRUPAL_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "drupal.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
         {{- else }}
         - name: MARIADB_HOST
           valueFrom:

--- a/drupal/templates/mysql-instance.yaml
+++ b/drupal/templates/mysql-instance.yaml
@@ -10,9 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   clusterServiceClassExternalName: azure-mysqldb
-  clusterServicePlanExternalName: "{{ .Values.mariadb.planName }}"
+  clusterServicePlanExternalName: {{ .Values.mysql.azure.servicePlan }}
   parameters:
-    location: "{{ .Values.mariadb.location }}"
+    location: {{ .Values.mysql.azure.location }}
     resourceGroup: {{ .Release.Namespace }}
     sslEnforcement: disabled
 {{- end }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -40,7 +40,7 @@ mysql:
     ## The Azure region in which to deploy Azure Database for MySQL
     location: eastus
     ## The plan to request for Azure Database for MySQL
-    servicePlan: standard800
+    servicePlan: standard100
 
 ##
 ## MariaDB chart configuration

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -31,30 +31,25 @@ drupalUsername: user
 ##
 drupalEmail: user@example.com
 
-## Set to `yes` to allow the container to be started with blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: yes
-
 mysql:
+  ## Whether to fulfill the dependency on MySQL using an embedded (on-cluster)
+  ## MariaDB database _instead of Azure Database for MySQL. This option is
+  ## available to enable local or no-cost evaluation of this chart.
   embeddedMaria: false
+  azure:
+    ## The Azure region in which to deploy Azure Database for MySQL
+    location: eastus
+    ## The plan to request for Azure Database for MySQL
+    servicePlan: standard800
 
 ##
 ## MariaDB chart configuration
 ##
 mariadb:
-  ## Whether to use the database specified as a requirement or not. For example, to configure the chart with an existing database server.
-  enabled: true
-
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
-
-  ## Related to the Azure Service Broker
-  # Plan to use for the MySQL Instance
-  planName: standard800
-  # Azure Location where to deploy the instance
-  location: eastus
 
   ## Create a database
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
@@ -111,7 +106,7 @@ ingress:
   ## Secrets must be manually created in the namespace
   ##
   # tls:
-  #   - secretName: wordpress.local-tls
+  #   - secretName: drupal.local-tls
   #     hosts:
   #       - drupal.local
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -188,7 +188,7 @@ livenessProbe:
   httpGet:
     path: /user/login
     port: http
-  initialDelaySeconds: 120
+  initialDelaySeconds: 600
 readinessProbe:
   httpGet:
     path: /user/login


### PR DESCRIPTION
_Partially_ addresses #76. It seems that if database initialization is cut short by an eager liveness check the first time through, the database gets totally borked and all subsequent restarts fail. I'll see if it's appropriate to open an issue upstream in k8s/charts, or perhaps against the Bitnami Drupal image we use. In the meantime, I've increased the initial delay on the liveness check to 10 minutes, which seems to be sufficient _on AKS_.

On minikube, this is not sufficient (due to latency?). I've tried increasing the initial delay to as much as half an hour, but it seems to have no effect as the setup process itself seems to timeout after about 15 minutes. This will need more investigation.

At the same time, this PR accomplishes a little bit of refactoring to promote long term maintainability:

- Fix embedded MariaDB option (wasn't working)
- Minimize differences with Drupal chart in k8s/charts
- Maximize similarity to other charts in this repo in terms of
  how Azure-specific things are handled

Also:

- Fix errant reference to Wordpress

Also:

- Reduces default service plan to standard100-- See #83 
