### PR TITLE
critical wordpress improvements

### DIFF
--- a/wordpress/Chart.yaml
+++ b/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.1.0
+version: 0.2.0
 appVersion: 4.8.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -96,7 +96,7 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `smtpPassword`                       | SMTP password                              | `nil`                                                      |
 | `smtpUsername`                       | User name for SMTP emails                  | `nil`                                                      |
 | `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                                      |
-| `mysql.embeddedMaria`                | Whether to fulfill the dependency on MySQL using an embedded (on-cluster) MariaDB database _instead of Aure Database for MySQL. This option is available to enable local or no-cost evaluation of this chart.            | `false`                                                    | 
+| `mysql.embeddedMaria`                | Whether to fulfill the dependency on MySQL using an embedded (on-cluster) MariaDB database _instead of Azure Database for MySQL. This option is available to enable local or no-cost evaluation of this chart.            | `false`                                                    | 
 | `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
 | `healthcheckHttps`                   | Use https for liveliness and readiness     | `false`                                             |
 | `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
@@ -113,14 +113,21 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `persistence.size`                   | PVC Storage Request                        | `10Gi`                                                     |
 | `nodeSelector`                       | Node labels for pod assignment             | `{}`                                                       |
 
+The following configuration options are utilized only if `mysql.embeddedMaria` is set to `false` (the default):
+
+| Parameter                            | Description                                | Default                                                    |
+| -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
+| `mysql.azure.location`            | The Azure region in which to deploy Azure Database for MySQL | `eastus`                                    |
+| `mysql.azure.servicePlan`         | The plan to request for Azure Database for MySQL             | `standard100`                               |
+
 The following configuration options are utilized only if `mysql.embeddedMaria` is set to `true`:
 
 | Parameter                            | Description                                | Default                                                    |
 | -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                     | `nil`                                                      |
-| `mariadb.mariadbDatabase`            | Database name to create                    | `bitnami_wordpress`                            |
-| `mariadb.mariadbUser`                | Database user to create                    | `bn_wordpress`                                 |
-| `mariadb.mariadbPassword`            | Password for the database                  | _random 10 character long alphanumeric string_ |
+| `mariadb.mariadbDatabase`            | Database name to create                    | `bitnami_wordpress`                                        |
+| `mariadb.mariadbUser`                | Database user to create                    | `bn_wordpress`                                             |
+| `mariadb.mariadbPassword`            | Password for the database                  | _random 10 character long alphanumeric string_             |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/wordpress/templates/mysql-instance.yaml
+++ b/wordpress/templates/mysql-instance.yaml
@@ -10,9 +10,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   clusterServiceClassExternalName: azure-mysqldb
-  clusterServicePlanExternalName: standard800
+  clusterServicePlanExternalName: {{ .Values.mysql.azure.servicePlan }}
   parameters:
-    location: eastus
+    location: {{ .Values.mysql.azure.location }}
     resourceGroup: {{ .Release.Namespace }}
     sslEnforcement: disabled
 {{- end }}

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -54,7 +54,15 @@ allowEmptyPassword: yes
 # smtpProtocol:
 
 mysql:
+  ## Whether to fulfill the dependency on MySQL using an embedded (on-cluster)
+  ## MariaDB database _instead of Azure Database for MySQL. This option is
+  ## available to enable local or no-cost evaluation of this chart.
   embeddedMaria: false
+  azure:
+    ## The Azure region in which to deploy Azure Database for MySQL
+    location: eastus
+    ## The plan to request for Azure Database for MySQL
+    servicePlan: standard100
 
 ##
 ## MariaDB chart configuration


### PR DESCRIPTION
Fixes #85
Relates to (partially addresses) #83 

- make azure location and service plan configurable
- reduce default service plan to standard100
- fix typos and some table formatting

I have tested this with favorable results on minikube _and_ AKS, using both the Azure DB for MySQL and embedded MariaDB options for each. Results are favorable for all four scenarios.
