### PR TITLE
Upgrade tiller command

### DIFF
--- a/docs/prerequisities/README.md
+++ b/docs/prerequisities/README.md
@@ -89,6 +89,7 @@ yourself. Simply run the following commands to complete the installation:
 ```console
 kubectl create -f https://raw.githubusercontent.com/Azure/helm-charts/master/docs/prerequisities/helm-rbac-config.yaml
 helm init --service-account tiller
+helm init --upgrade
 ```
 
 # Step 3: Install Service Catalog


### PR DESCRIPTION
ACS Engine provisioned cluster already had Helm installed (message below)

```
helm init --service-account tiller
$HELM_HOME has been configured at /Users/sabbour/.helm.
Warning: Tiller is already installed in the cluster.
```

However, the tiller installed was an older version

```
helm install svc-cat/catalog --name catalog --namespace catalog
Error: incompatible versions client[v2.7.2] server[v2.6.2]
```

Proposed solution is to upgrade tiller by running:

```
helm init --upgrade
```