### PR TITLE
Make chart dependency builds immutable

### DIFF
--- a/scripts/helm-repo-sync.sh
+++ b/scripts/helm-repo-sync.sh
@@ -21,7 +21,7 @@ for dir in `ls ../..`;do
         echo "skipping $dir because it lacks a Chart.yaml file"
     else
         echo "packaging $dir"
-        helm dep update ../../$dir
+        helm dep build ../../$dir
         helm package ../../$dir
     fi
 done


### PR DESCRIPTION
Rationale, cribbed from Matt Farina's [similar PR to kubernetes/charts](https://github.com/kubernetes/charts/commit/59472e816349940a2706f20a82985198840c6508):

> The previous version of the sync script ran `helm dep update` which
would recreate the requirements.lock file. This caused new builds
of charts as a total package with different versions of dependencies
but the same chart version. The package was mutating.
>
> This change works towards our goal of immutable charts for a chart
at a version.