### PR TITLE
Bump helm-chart-publishing-tools image to v0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.0
+      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.1
     working_directory: /charts
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
           working_directory: scripts
   helm-sync:
     docker:
-      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.0
+      - image: quay.io/deis/helm-chart-publishing-tools:v0.1.1
     working_directory: /charts
     steps:
       - checkout


### PR DESCRIPTION
* Uses az go cli instead of the python cli