### PR TITLE
Update wordpress version and chart with support for prod envs and istio

### DIFF
--- a/wordpress/Chart.yaml
+++ b/wordpress/Chart.yaml
@@ -1,6 +1,6 @@
 name: wordpress
-version: 0.10.0
-appVersion: 4.9.4
+version: 0.10.1
+appVersion: 4.9.8
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/wordpress/templates/NOTES.txt
+++ b/wordpress/templates/NOTES.txt
@@ -37,3 +37,14 @@
 
   echo Username: {{ .Values.wordpressUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+
+{{- if not .Values.mariadb.enabled}}
+
+3. To get your Wordpress database connection details use the following:
+
+  echo Database: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-mysql-secret -o jsonpath="{.data.database}" | base64 --decode)
+  echo Host: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-mysql-secret -o jsonpath="{.data.host}" | base64 --decode)
+  echo Username: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-mysql-secret -o jsonpath="{.data.username}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-mysql-secret -o jsonpath="{.data.password}" | base64 --decode)
+  echo Port: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-mysql-secret -o jsonpath="{.data.port}" | base64 --decode)
+{{- end}}

--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.apiVersion }}
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -8,11 +8,19 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+      annotations:
+        sidecar.istio.io/inject: "{{ default "false" .Values.istioSidecar.enabled }}"
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/wordpress/templates/deployment.yaml
+++ b/wordpress/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
       - name: wordpress-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{ end }}

--- a/wordpress/templates/mysql-instance.yaml
+++ b/wordpress/templates/mysql-instance.yaml
@@ -9,12 +9,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  clusterServiceClassExternalName: azure-mysql-5-7
+  clusterServiceClassExternalName: {{ .Values.externalDatabase.azure.serviceName }}
   clusterServicePlanExternalName: {{ .Values.externalDatabase.azure.servicePlan }}
   parameters:
     location: {{ .Values.externalDatabase.azure.location }}
     resourceGroup: {{ .Release.Namespace }}
-    sslEnforcement: disabled
+    sslEnforcement: {{ .Values.externalDatabase.azure.ssl }}
     firewallRules:
     - startIPAddress: "0.0.0.0"
       endIPAddress: "255.255.255.255"

--- a/wordpress/templates/pvc.yaml
+++ b/wordpress/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -1,7 +1,16 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.9.4-r0
+apiVersion: extensions/v1beta1
+image: bitnami/wordpress:4.9.8
+
+## Specify the number of replicas
+replicaCount: 3
+
+## enable istio sidecar
+## ref: https://istio.io/docs/setup/kubernetes/sidecar-injection/#configuration-options
+istioSidecar:
+  enabled: true
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -51,11 +60,17 @@ wordpressBlogName: User's Blog!
 
 externalDatabase:
 ## All of these values are only used when mariadb.enabled is set to false
+
+## Azure DB for MySql config
+## ref: https://github.com/Azure/open-service-broker-azure/blob/master/docs/modules/mysql.md
   azure:
+    ## Service name  (there are 3 types)
+    serviceName: azure-mysql-5-7
     ## The Azure region in which to deploy Azure Database for MySQL
     location: eastus
     ## The plan to request for Azure Database for MySQL
     servicePlan: general-purpose
+    ssl: disabled
 
 ##
 ## MariaDB chart configuration
@@ -140,22 +155,21 @@ ingress:
 
     ## Set this to true in order to enable TLS on the ingress record
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
+
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     tls: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: wordpress.local-tls
 
-    ## Ingress annotations done as key:value pairs
-    ## If you're using kube-lego, you will want to add:
-    ## kubernetes.io/tls-acme: true
-    ##
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
-    ##
-    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If using istio, set ingress.class to istio
+    ## If you're using cert-manager, you will want to enable tls-acme
+     ## If using certmanager, specify cluster-issuer
+     ## ref: http://docs.cert-manager.io/en/latest/getting-started/3-configuring-first-issuer.html
     annotations:
     #  kubernetes.io/ingress.class: nginx
     #  kubernetes.io/tls-acme: true
+    #  certmanager.k8s.io/cluster-issuer: letsencrypt-prod
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
@@ -163,7 +177,7 @@ ingress:
   ## -----BEGIN RSA PRIVATE KEY-----
   ##
   ## name should line up with a tlsSecret set further up
-  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information

--- a/wordpress/values.yaml
+++ b/wordpress/values.yaml
@@ -5,12 +5,14 @@ apiVersion: extensions/v1beta1
 image: bitnami/wordpress:4.9.8
 
 ## Specify the number of replicas
+## If using more than one (replicas are recommended for production), you will also need to provide a ReadWriteMany PVC with a storageClass of "nfs"
+## more on line 193 under "persistence"
 replicaCount: 3
 
 ## enable istio sidecar
 ## ref: https://istio.io/docs/setup/kubernetes/sidecar-injection/#configuration-options
 istioSidecar:
-  enabled: true
+  enabled: false
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -190,7 +192,7 @@ ingress:
 ##
 persistence:
   enabled: true
-  ## wordpress data Persistent Volume Storage Class
+  ### wordpress data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
@@ -198,6 +200,17 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC using
+  ## the existingClaim variable
+  # existingClaim: your-claim
+  ##
+  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
+  ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
+  ## We recommend that you install the nfs provisioner and map it to a RWO volume
+  ## helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi
+  ## accessMode: ReadWriteOnce can be used in test/dev environments but is not recommended for production
+  ## accessMode: ReadWriteMany for production
   accessMode: ReadWriteOnce
   size: 10Gi
 


### PR DESCRIPTION
Updated wordpress chart with the following additions/revisions:
- support for replicas, istio and certmanager
- support for existing PVC & clarify replica deps for prod enviroments
- add in support for SSL and type of azure mysql db deployment
- support for istio sidecare and apiVersion deployment changes
- Update Notes with how to get wordpress database connection details
- Update version of wordpress from 4.9.4 to 4.9.8
- bump chart version
