### PR TITLE
Removing wrong statement in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains [Helm](https://helm.sh/) charts for use with the
 and
 [Microsoft Open Service Broker for Azure](https://github.com/Azure/open-service-broker-azure).
 
-| 🚨  | The project is in **alpha** status. This means that no assurances are made about backwards compatibility or stability until [Open Service Broker for Azure](https://github.com/Azure/open-service-broker-azure) has reached v1. |
+| 🚨  | The project is in **alpha** status. This means that no assurances are made about backwards compatibility or stability. |
 |---|---|
 
 Each chart has one or more dependencies on Azure services (e.g. Azure SQL, CosmosDB, ...)


### PR DESCRIPTION
Hi,

Just a small change in the README.md, removing the reference to the Open Service Broker for Azure not reaching V1 yet, as it has reach [V1](https://github.com/Azure/open-service-broker-azure/releases/tag/v1.0.0) in June.
Maybe it would be great to add something else instead, something like by when the project aims to go to beta stage?