### PR TITLE
Drupal: Add Redis local and PaaS options

### DIFF
--- a/drupal/requirements.lock
+++ b/drupal/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.0.1
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.0.5
-digest: sha256:277208f8ee8fd30e560fcd0ed6c6e1a749f273fab29b0dc31a55dd922ca9c278
-generated: 2017-12-06T12:50:46.312368-05:00
+digest: sha256:29aded389125c8001f417e6abea5c8a74d7fb41507378e06fa4bfaf5c5896b02
+generated: 2019-05-22T10:33:36.439368103+02:00

--- a/drupal/requirements.lock
+++ b/drupal/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.0.5
-digest: sha256:29aded389125c8001f417e6abea5c8a74d7fb41507378e06fa4bfaf5c5896b02
-generated: 2019-05-22T10:33:36.439368103+02:00
+digest: sha256:bf3f23c18ed3a291cb10ca084435a3b71ab2ad1ba85f72ab6c3b572b9c21d07b
+generated: 2019-05-22T10:52:51.38793075+02:00

--- a/drupal/requirements.yaml
+++ b/drupal/requirements.yaml
@@ -1,4 +1,8 @@
 dependencies:
+- name: redis
+  version: 8.0.1
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: redis.embeddedRedis
 - name: mariadb
   version: 1.0.5
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/drupal/requirements.yaml
+++ b/drupal/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
 - name: redis
   version: 8.0.1
   repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: redis.embeddedRedis
+  condition: redis.enabled, redis.embeddedRedis
 - name: mariadb
   version: 1.0.5
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -19,12 +19,13 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
-        {{- if .Values.redis.embeddedRedis }}
+        {{- if and .Values.redis.enabled (.Values.redis.embeddedRedis) }}
         - name: REDIS_HOST
           value: {{ template "drupal.redis.fullname" . }}
         - name: REDIS_PORT_NUMBER
           value: "6380"
-        {{- else }}
+        {{- end}}
+        {{- if and .Values.redis.enabled (not .Values.redis.embeddedRedis) }}
         - name: REDIS_HOST
           valueFrom:
             secretKeyRef:

--- a/drupal/templates/deployment.yaml
+++ b/drupal/templates/deployment.yaml
@@ -19,6 +19,23 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        {{- if .Values.redis.embeddedRedis }}
+        - name: REDIS_HOST
+          value: {{ template "drupal.redis.fullname" . }}
+        - name: REDIS_PORT_NUMBER
+          value: "6380"
+        {{- else }}
+        - name: REDIS_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "drupal.fullname" . }}-redis-secret
+              key: host
+        - name: REDIS_PORT_NUMBER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "drupal.fullname" . }}-redis-secret
+              key: port
+        {{- end }}
         {{- if .Values.mysql.embeddedMaria }}
         - name: MARIADB_HOST
           value: {{ template "drupal.mariadb.fullname" . }}

--- a/drupal/templates/redis-binding.yaml
+++ b/drupal/templates/redis-binding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.redis.embeddedRedis }}
+{{- if and .Values.redis.enabled (not .Values.redis.embeddedRedis) }}
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:

--- a/drupal/templates/redis-binding.yaml
+++ b/drupal/templates/redis-binding.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.redis.embeddedRedis }}
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: {{ template "drupal.fullname" . }}-redis-binding
+  labels:
+    app: {{ template "drupal.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  instanceRef:
+    name: {{ template "drupal.fullname" . }}-redis-instance
+  secretName: {{ template "drupal.fullname" . }}-redis-secret
+{{- end }}

--- a/drupal/templates/redis-instance.yaml
+++ b/drupal/templates/redis-instance.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.redis.embeddedRedis }}
+{{- if and .Values.redis.enabled (not .Values.redis.embeddedRedis) }}
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceInstance
 metadata:

--- a/drupal/templates/redis-instance.yaml
+++ b/drupal/templates/redis-instance.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.redis.embeddedRedis }}
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: {{ template "drupal.fullname" . }}-redis-instance
+  labels:
+    app: {{ template "drupal.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterServiceClassExternalName: azure-rediscache
+  clusterServicePlanExternalName: {{ .Values.redis.azure.servicePlan }}
+  parameters:
+    location: {{ .Values.redis.azure.location }}
+    resourceGroup: {{ .Release.Namespace }}
+    enableNonSslPort: disabled
+{{- end }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -31,6 +31,12 @@ drupalUsername: user
 ##
 drupalEmail: user@example.com
 
+redis:
+  embeddedRedis: false
+  azure:
+    location: eastus
+    servicePlan: standard
+
 mysql:
   ## Whether to fulfill the dependency on MySQL using an embedded (on-cluster)
   ## MariaDB database _instead of Azure Database for MySQL. This option is

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -32,6 +32,7 @@ drupalUsername: user
 drupalEmail: user@example.com
 
 redis:
+  enabled: false
   embeddedRedis: false
   azure:
     location: eastus


### PR DESCRIPTION
Redis is an extremely popular cache system for Drupal sites, and a common best practice. This PR includes the ability to optionally enable an embedded or Azure PaaS version of Redis. Disabled by default.